### PR TITLE
Use regex in truncateUrl util

### DIFF
--- a/src/components/PairingCard.tsx
+++ b/src/components/PairingCard.tsx
@@ -1,4 +1,4 @@
-import { truncate } from '@/utils/HelperUtil'
+import { truncateUrl } from '@/utils/HelperUtil'
 import { Avatar, Button, Card, Link, Text, Tooltip } from '@nextui-org/react'
 import Image from 'next/image'
 
@@ -40,7 +40,7 @@ export default function PairingCard({ logo, name, url, onDelete }: IProps) {
             {name}
           </Text>
           <Link href={url} css={{ marginLeft: '$9' }}>
-            {truncate(url?.split('https://')[1] ?? 'Unknown', 23)}
+            {truncateUrl(url)}
           </Link>
         </div>
         <Tooltip content="Delete" placement="left">

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -1,4 +1,4 @@
-import { truncate } from '@/utils/HelperUtil'
+import { truncateUrl } from '@/utils/HelperUtil'
 import { Avatar, Card, Link, Text } from '@nextui-org/react'
 import Image from 'next/image'
 import NextLink from 'next/link'
@@ -43,7 +43,7 @@ export default function SessionCard({ logo, name, url, topic }: IProps) {
               {name}
             </Text>
             <Link href={url} css={{ marginLeft: '$9' }}>
-              {truncate(url?.split('https://')[1] ?? 'Unknown', 23)}
+              {truncateUrl(url)}
             </Link>
           </div>
 

--- a/src/utils/HelperUtil.ts
+++ b/src/utils/HelperUtil.ts
@@ -106,3 +106,7 @@ export function formatChainName(chainId: string) {
     chainId
   )
 }
+
+export function truncateUrl(url: string | undefined) {
+  return truncate(url?.split(/http[s]?:\/\//)[1] ?? 'Unknown', 23)
+}


### PR DESCRIPTION
### Summary
Previous functionality naively split on 'https://'. This update splits the on 'http://' or 'https://' using regex
<img width="450" alt="Screenshot 2023-07-06 at 4 21 00 PM" src="https://github.com/hgraph-io/hedera-walletconnect-wallet/assets/136644362/8c844754-f203-4923-9917-a635e3bae8db">
<img width="450" alt="Screenshot 2023-07-06 at 4 21 08 PM" src="https://github.com/hgraph-io/hedera-walletconnect-wallet/assets/136644362/69880a58-c43a-4eda-aeb6-3e876646d2eb">
