### PR TITLE
Parse the transaction bytes, sign, and submit to network

### DIFF
--- a/src/utils/HederaRequestHandlerUtil.ts
+++ b/src/utils/HederaRequestHandlerUtil.ts
@@ -2,17 +2,25 @@ import { HEDERA_SIGNING_METHODS } from '@/data/HederaData'
 import { formatJsonRpcError, formatJsonRpcResult } from '@json-rpc-tools/utils'
 import { SignClientTypes } from '@walletconnect/types'
 import { getSdkError } from '@walletconnect/utils'
+import { hederaWallet } from './HederaWalletUtil'
 
 export async function approveHederaRequest(
   requestEvent: SignClientTypes.EventArguments['session_request']
 ) {
-  const { params, id, topic } = requestEvent
-  const { chainId, request } = params
+  const { params, id } = requestEvent
+  const { request } = params
 
   switch (request.method) {
     case HEDERA_SIGNING_METHODS.HEDERA_SIGN_AND_SEND_TRANSACTION:
       console.log('approve', { method: request.method, id, params })
-      return formatJsonRpcResult(id, { requestParams: request.params })
+      try {
+        const transactionBytes = new Uint8Array(Object.values(request.params.transaction))
+        const result = await hederaWallet.signAndSendTransaction(transactionBytes)
+        return formatJsonRpcResult(id, result)
+      } catch (e) {
+        console.log(e)
+      }
+
     default:
       throw new Error(getSdkError('INVALID_METHOD').message)
   }


### PR DESCRIPTION
### Summary
Updates `HederaLib` and `HederaRequestHandler` to parse the transaction bytes from the session request, recreate the Transaction, sign, and submit to the testnet.

Note: I realize that the transaction presented to the user is quite unreadable, as it is a Proxy Object of a Uint8Array. I'll work on improving that next.

https://github.com/hgraph-io/hedera-walletconnect-wallet/assets/136644362/cbab889f-3674-4968-8473-8747b3840053

