### PR TITLE
Decode transaction bytes from base64 string

### DIFF
--- a/src/lib/HederaLib.ts
+++ b/src/lib/HederaLib.ts
@@ -31,9 +31,10 @@ export class HederaWallet {
     }
   }
 
-  public transactionFromBytes(transactionBytes: Uint8Array) {
-    if (!transactionBytes?.byteLength) return null
-    return Transaction.fromBytes(transactionBytes)
+  public transactionFromEncodedBytes(transactionBytes: string) {
+    if (!transactionBytes) return null
+    const decoded = Buffer.from(transactionBytes, 'base64')
+    return Transaction.fromBytes(decoded)
   }
 
   public async signAndSendTransaction(transaction: Transaction) {

--- a/src/utils/HederaRequestHandlerUtil.ts
+++ b/src/utils/HederaRequestHandlerUtil.ts
@@ -14,8 +14,9 @@ export async function approveHederaRequest(
     case HEDERA_SIGNING_METHODS.HEDERA_SIGN_AND_SEND_TRANSACTION:
       console.log('approve', { method: request.method, id, params })
       try {
-        const txnBytes = new Uint8Array(Object.values(params.request.params.transaction.bytes))
-        const transaction = hederaWallet.transactionFromBytes(txnBytes)
+        const transaction = hederaWallet.transactionFromEncodedBytes(
+          params.request.params.transaction.bytes
+        )
         if (!transaction) {
           return formatJsonRpcError(id, 'Unable to build transaction from bytes.')
         }

--- a/src/views/SessionSignHederaModal.tsx
+++ b/src/views/SessionSignHederaModal.tsx
@@ -20,18 +20,11 @@ import { Fragment } from 'react'
 type HederaSignAndSendTransactionParams = {
   transaction: {
     type: string
-    bytes: Record<string, number>
+    bytes: string
   }
 }
 
 type SessionRequestParams = SignClientTypes.EventArguments['session_request']['params']
-
-const buildTransactionFromBytes = (
-  transaction: HederaSignAndSendTransactionParams['transaction']
-) => {
-  const txnBytes = new Uint8Array(Object.values(transaction.bytes))
-  return hederaWallet.transactionFromBytes(txnBytes)
-}
 
 type SummaryDetailProps = {
   label: string
@@ -56,7 +49,7 @@ const SummaryDetail = ({ label, data }: SummaryDetailProps) => {
 
 const SignAndSendTransactionSummary = ({ params }: { params: SessionRequestParams }) => {
   const { transaction } = params.request.params as HederaSignAndSendTransactionParams
-  const transactionFromBytes = buildTransactionFromBytes(transaction)
+  const transactionFromBytes = hederaWallet.transactionFromEncodedBytes(transaction.bytes)
   const shouldShow = transaction.bytes && transactionFromBytes
 
   if (!shouldShow) return null


### PR DESCRIPTION
### Summary
Decodes the `params.transaction.bytes` base64 encoded string and recreates the transaction from the resulting bytes array.

https://github.com/hgraph-io/hedera-walletconnect-wallet/assets/136644362/a6e170ed-3bad-44b6-8672-be54914799f6

